### PR TITLE
Enhance CSRF Token Handling for AJAX Requests

### DIFF
--- a/account/templates/base.html
+++ b/account/templates/base.html
@@ -48,7 +48,21 @@
   </div>
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/
 jquery.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/js-cookie@2.2.1/src/
+js.cookie.min.js"></script>
 <script>
+  var csrftoken = Cookies.get('csrftoken');
+  function csrfSafeMethod(method) {
+  // these HTTP methods do not require CSRF protection
+  return (/^(GET|HEAD|OPTIONS|TRACE)$/.test(method));
+  }
+  $.ajaxSetup({
+  beforeSend: function(xhr, settings) {
+  if (!csrfSafeMethod(settings.type) && !this.crossDomain) {
+  xhr.setRequestHeader("X-CSRFToken", csrftoken);
+  }
+  }
+  });
  $(document).ready(function(){
   {% block domready %}
   {% endblock %}


### PR DESCRIPTION
## Changes Made
### base.html
- Modified the JavaScript code in the `base.html` template to enhance CSRF token handling for AJAX requests.
- Included the JS Cookie plugin from a public CDN to interact with cookies easily.
- Introduced the `csrftoken` variable to store the CSRF token value retrieved from the `csrftoken` cookie.
- Defined the `csrfSafeMethod()` function to determine whether an HTTP method is safe and does not require CSRF protection.
- Utilized `$.ajaxSetup()` to set up jQuery AJAX requests, ensuring the inclusion of the CSRF token in headers for unsafe HTTP methods.